### PR TITLE
Fix product mapper warning and add global exception handler

### DIFF
--- a/src/main/java/com/fiap/fast_food_tc/adapter/controller/CheckoutController.java
+++ b/src/main/java/com/fiap/fast_food_tc/adapter/controller/CheckoutController.java
@@ -24,12 +24,7 @@ public class CheckoutController {
 
     @PostMapping("/{orderId}")
     public ResponseEntity<String> checkout(@PathVariable Integer orderId) {
-        try {
-            return ResponseEntity.ok(checkoutService.paymentPreferenceProcess(orderId));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("Error to post checkout: " + e.getMessage());
-        }
+        return ResponseEntity.ok(checkoutService.paymentPreferenceProcess(orderId));
     }
 
 }

--- a/src/main/java/com/fiap/fast_food_tc/cross/exception/ErrorResponse.java
+++ b/src/main/java/com/fiap/fast_food_tc/cross/exception/ErrorResponse.java
@@ -1,0 +1,6 @@
+package com.fiap.fast_food_tc.cross.exception;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(LocalDateTime timestamp, int status, String message) {
+}

--- a/src/main/java/com/fiap/fast_food_tc/cross/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fiap/fast_food_tc/cross/exception/GlobalExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.fiap.fast_food_tc.cross.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(err -> err.getField() + " " + err.getDefaultMessage())
+                .findFirst()
+                .orElse(ex.getMessage());
+        ErrorResponse error = new ErrorResponse(LocalDateTime.now(), HttpStatus.BAD_REQUEST.value(), message);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    @ExceptionHandler({IllegalArgumentException.class, RuntimeException.class})
+    public ResponseEntity<ErrorResponse> handleNotFound(RuntimeException ex) {
+        ErrorResponse error = new ErrorResponse(LocalDateTime.now(), HttpStatus.NOT_FOUND.value(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalState(IllegalStateException ex) {
+        ErrorResponse error = new ErrorResponse(LocalDateTime.now(), HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleDefault(Exception ex) {
+        ErrorResponse error = new ErrorResponse(LocalDateTime.now(), HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+}

--- a/src/main/java/com/fiap/fast_food_tc/cross/mapper/ProductMapper.java
+++ b/src/main/java/com/fiap/fast_food_tc/cross/mapper/ProductMapper.java
@@ -15,6 +15,7 @@ public interface ProductMapper {
     ProductResponse toResponse(EProduct product);
 
     @Mapping(target = "orderProducts", ignore = true)
+    @Mapping(target = "category.categoryId", source = "categoryId")
     Product toModel(EProduct product);
 
     @Mapping(source = "category.categoryId", target = "categoryId")

--- a/src/test/java/com/fiap/fast_food_tc/unit/adapter/controller/CheckoutControllerTest.java
+++ b/src/test/java/com/fiap/fast_food_tc/unit/adapter/controller/CheckoutControllerTest.java
@@ -35,9 +35,6 @@ class CheckoutControllerTest {
     void checkoutFailure() {
         Mockito.when(checkoutService.paymentPreferenceProcess(1)).thenThrow(new RuntimeException("fail"));
 
-        var response = controller.checkout(1);
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        assertNotNull(response.getBody());
+        assertThrows(RuntimeException.class, () -> controller.checkout(1));
     }
 }


### PR DESCRIPTION
## Summary
- map `categoryId` to nested category in `ProductMapper`
- create `ErrorResponse` record
- add `GlobalExceptionHandler` under new `cross.exception` package
- simplify `CheckoutController` by removing try/catch
- adjust `CheckoutControllerTest` accordingly

## Testing
- `./gradlew test --no-daemon`