### PR TITLE
Add provider unit tests

### DIFF
--- a/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/CategoryDataProviderTest.java
+++ b/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/CategoryDataProviderTest.java
@@ -1,0 +1,75 @@
+package com.fiap.fast_food_tc.unit.adapter.provider;
+
+import com.fiap.fast_food_tc.adapter.db.model.Category;
+import com.fiap.fast_food_tc.adapter.db.repository.CategoryRepository;
+import com.fiap.fast_food_tc.adapter.provider.CategoryDataProvider;
+import fixture.CategoryFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryDataProviderTest {
+
+    @Mock
+    private CategoryRepository repository;
+
+    @InjectMocks
+    private CategoryDataProvider provider;
+
+    @Test
+    void findAllCategoriesSuccess() {
+        List<Category> categories = List.of(CategoryFixture.createCategoryModel());
+        when(repository.findAll()).thenReturn(categories);
+
+        var result = provider.findAllCategories();
+
+        assertEquals(categories, result);
+    }
+
+    @Test
+    void findCategoryByIdSuccess() {
+        Category category = CategoryFixture.createCategoryModel();
+        when(repository.findById(1)).thenReturn(Optional.of(category));
+
+        var result = provider.findCategoryById(1);
+
+        assertEquals(category, result);
+    }
+
+    @Test
+    void createCategorySuccess() {
+        Category category = CategoryFixture.createCategoryModel();
+        when(repository.save(category)).thenReturn(category);
+
+        var result = provider.createCategory(category);
+
+        assertEquals(category, result);
+    }
+
+    @Test
+    void deleteCategorySuccess() {
+        provider.deleteCategory(1);
+
+        verify(repository).deleteById(1);
+    }
+
+    @Test
+    void updateCategorySuccess() {
+        Category category = CategoryFixture.createCategoryModel();
+        when(repository.save(category)).thenReturn(category);
+
+        var result = provider.updateCategory(category);
+
+        assertEquals(category, result);
+    }
+}

--- a/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/CheckoutDataProviderTest.java
+++ b/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/CheckoutDataProviderTest.java
@@ -1,0 +1,92 @@
+package com.fiap.fast_food_tc.unit.adapter.provider;
+
+import com.fiap.fast_food_tc.adapter.db.model.OrderProduct;
+import com.fiap.fast_food_tc.adapter.db.model.Orders;
+import com.fiap.fast_food_tc.adapter.db.model.Payment;
+import com.fiap.fast_food_tc.adapter.db.model.Product;
+import com.fiap.fast_food_tc.adapter.db.model.ids.OrderProductPk;
+import com.fiap.fast_food_tc.adapter.dto.checkout.PreferenceResponse;
+import com.fiap.fast_food_tc.adapter.provider.CheckoutDataProvider;
+import com.fiap.fast_food_tc.adapter.provider.OrdersDataProvider;
+import com.fiap.fast_food_tc.adapter.provider.PaymentDataProvider;
+import com.fiap.fast_food_tc.adapter.provider.clients.MercadoPagoClient;
+import com.fiap.fast_food_tc.cross.enums.PaymentMethod;
+import com.fiap.fast_food_tc.cross.enums.PaymentStatus;
+import fixture.CustomerFixture;
+import fixture.ProductFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CheckoutDataProviderTest {
+
+    @Mock
+    private MercadoPagoClient mercadoPagoClient;
+    @Mock
+    private PaymentDataProvider paymentDataProvider;
+    @Mock
+    private OrdersDataProvider ordersDataProvider;
+
+    @InjectMocks
+    private CheckoutDataProvider provider;
+
+    @Test
+    void getPaymentLinkSuccess() {
+        Orders order = createOrder();
+        PreferenceResponse response = PreferenceResponse.builder()
+                .id("123")
+                .initPoint("http://pay")
+                .build();
+
+        when(ordersDataProvider.getById(1)).thenReturn(order);
+        when(mercadoPagoClient.createPreference(any())).thenReturn(response);
+        when(paymentDataProvider.save(any())).thenReturn(null);
+
+        String link = provider.getPaymentLink(1);
+
+        assertEquals("http://pay", link);
+        verify(mercadoPagoClient).createPreference(any());
+
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentDataProvider).save(captor.capture());
+        Payment saved = captor.getValue();
+        assertEquals(order.getCustomer().getCustomerId(), saved.getCustomerId());
+        assertEquals(order.getTotalAmount(), saved.getPaymentValue());
+        assertEquals(PaymentStatus.PENDING, saved.getPaymentStatus());
+        assertEquals(PaymentMethod.MERCADO_PAGO, saved.getPaymentMethod());
+        assertEquals("123", saved.getMercadoPagoId());
+        assertNotNull(saved.getCreatedAt());
+    }
+
+    private Orders createOrder() {
+        Orders order = Orders.builder()
+                .orderId(1)
+                .totalAmount(BigDecimal.TEN)
+                .customer(CustomerFixture.createCustomerModel())
+                .orderDatetime(LocalDateTime.now())
+                .statusOrder(1)
+                .build();
+
+        Product product = ProductFixture.createProduct();
+        OrderProduct op = new OrderProduct();
+        op.setOrders(order);
+        op.setProduct(product);
+        op.setProductQuantity(2);
+        op.setProductTotalAmount(BigDecimal.TEN);
+        op.setId(new OrderProductPk(order.getOrderId(), product.getProductId()));
+        order.setOrderProducts(List.of(op));
+        return order;
+    }
+}

--- a/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/CustomerDataProviderTest.java
+++ b/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/CustomerDataProviderTest.java
@@ -1,0 +1,85 @@
+package com.fiap.fast_food_tc.unit.adapter.provider;
+
+import com.fiap.fast_food_tc.adapter.db.model.Customer;
+import com.fiap.fast_food_tc.adapter.db.repository.CustomerRepository;
+import com.fiap.fast_food_tc.adapter.provider.CustomerDataProvider;
+import fixture.CustomerFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CustomerDataProviderTest {
+
+    @Mock
+    private CustomerRepository repository;
+
+    @InjectMocks
+    private CustomerDataProvider provider;
+
+    @Test
+    void createSuccess() {
+        Customer model = CustomerFixture.createCustomerModel();
+        when(repository.save(model)).thenReturn(model);
+
+        var result = provider.create(model);
+
+        assertEquals(model, result);
+    }
+
+    @Test
+    void findByDocumentNumberSuccess() {
+        Customer model = CustomerFixture.createCustomerModel();
+        when(repository.findByDocumentNumber("111111")).thenReturn(Optional.of(model));
+
+        var result = provider.findByDocumentNumber("111111");
+
+        assertEquals(model, result);
+    }
+
+    @Test
+    void findByIdSuccess() {
+        Customer model = CustomerFixture.createCustomerModel();
+        when(repository.findById(1)).thenReturn(Optional.of(model));
+
+        var result = provider.findById(1);
+
+        assertEquals(model, result);
+    }
+
+    @Test
+    void updateSuccess() {
+        Customer model = CustomerFixture.createCustomerModel();
+        when(repository.save(any())).thenReturn(model);
+
+        var result = provider.update(model);
+
+        assertEquals(model, result);
+    }
+
+    @Test
+    void deleteSuccess() {
+        provider.delete(1);
+
+        verify(repository).deleteById(1);
+    }
+
+    @Test
+    void findAllSuccess() {
+        List<Customer> list = List.of(CustomerFixture.createCustomerModel());
+        when(repository.findAll()).thenReturn(list);
+
+        var result = provider.findAll();
+
+        assertEquals(list, result);
+    }
+}

--- a/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/OrderProductDataProviderTest.java
+++ b/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/OrderProductDataProviderTest.java
@@ -1,0 +1,85 @@
+package com.fiap.fast_food_tc.unit.adapter.provider;
+
+import com.fiap.fast_food_tc.adapter.db.model.OrderProduct;
+import com.fiap.fast_food_tc.adapter.db.model.ids.OrderProductPk;
+import com.fiap.fast_food_tc.adapter.db.repository.OrderProductRepository;
+import com.fiap.fast_food_tc.adapter.provider.OrderProductDataProvider;
+import fixture.OrderProductFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderProductDataProviderTest {
+
+    @Mock
+    private OrderProductRepository repository;
+
+    @InjectMocks
+    private OrderProductDataProvider provider;
+
+    @Test
+    void createSuccess() {
+        OrderProduct op = OrderProductFixture.createOrderProduct();
+        when(repository.save(any())).thenReturn(op);
+
+        var result = provider.create(op);
+
+        assertEquals(op, result);
+        verify(repository).save(op);
+    }
+
+    @Test
+    void getAllSuccess() {
+        List<OrderProduct> list = List.of(OrderProductFixture.createOrderProduct());
+        when(repository.findAll()).thenReturn(list);
+
+        var result = provider.getAll();
+
+        assertEquals(list, result);
+    }
+
+    @Test
+    void getByIdSuccess() {
+        OrderProduct op = OrderProductFixture.createOrderProduct();
+        when(repository.findById(op.getId())).thenReturn(Optional.of(op));
+
+        var result = provider.getById(op.getId());
+
+        assertEquals(op, result);
+    }
+
+    @Test
+    void updateSuccess() {
+        OrderProduct existing = OrderProductFixture.createOrderProduct();
+        OrderProductPk pk = existing.getId();
+        when(repository.findById(pk)).thenReturn(Optional.of(existing));
+        when(repository.save(any())).thenReturn(existing);
+
+        OrderProduct update = OrderProductFixture.createOrderProduct();
+        update.setProductQuantity(5);
+
+        var result = provider.update(update);
+
+        assertEquals(existing, result);
+        verify(repository).save(existing);
+    }
+
+    @Test
+    void deleteSuccess() {
+        OrderProductPk pk = OrderProductFixture.createOrderProduct().getId();
+
+        provider.delete(pk);
+
+        verify(repository).deleteById(pk);
+    }
+}

--- a/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/OrdersDataProviderTest.java
+++ b/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/OrdersDataProviderTest.java
@@ -1,0 +1,107 @@
+package com.fiap.fast_food_tc.unit.adapter.provider;
+
+import com.fiap.fast_food_tc.adapter.db.model.Orders;
+import com.fiap.fast_food_tc.adapter.db.repository.OrdersRepository;
+import com.fiap.fast_food_tc.adapter.provider.OrdersDataProvider;
+import fixture.CustomerFixture;
+import fixture.OrdersFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrdersDataProviderTest {
+
+    @Mock
+    private OrdersRepository repository;
+
+    @InjectMocks
+    private OrdersDataProvider provider;
+
+    @Test
+    void getAllOrdersSuccess() {
+        List<Orders> list = List.of(OrdersFixture.createOrders());
+        when(repository.findAll()).thenReturn(list);
+
+        var result = provider.getAllOrders();
+
+        assertEquals(list, result);
+    }
+
+    @Test
+    void createSuccess() {
+        Orders order = OrdersFixture.createOrders();
+        when(repository.save(order)).thenReturn(order);
+
+        var result = provider.create(order);
+
+        assertEquals(order, result);
+    }
+
+    @Test
+    void getByIdSuccess() {
+        Orders order = OrdersFixture.createOrders();
+        when(repository.findById(1)).thenReturn(Optional.of(order));
+
+        var result = provider.getById(1);
+
+        assertEquals(order, result);
+    }
+
+    @Test
+    void updateSuccess() {
+        Orders existing = OrdersFixture.createOrders();
+        when(repository.findById(existing.getOrderId())).thenReturn(Optional.of(existing));
+        when(repository.save(any())).thenReturn(existing);
+
+        Orders update = Orders.builder()
+                .orderId(existing.getOrderId())
+                .orderDatetime(LocalDateTime.now())
+                .statusOrder(3)
+                .totalAmount(BigDecimal.TEN)
+                .customer(CustomerFixture.createCustomerModel())
+                .build();
+
+        var result = provider.update(update);
+
+        assertEquals(existing, result);
+        verify(repository).save(existing);
+    }
+
+    @Test
+    void deleteSuccess() {
+        provider.delete(1);
+
+        verify(repository).deleteById(1);
+    }
+
+    @Test
+    void getLastOrderCodeSuccess() {
+        Orders order = OrdersFixture.createOrders();
+        when(repository.findFirstByOrderByOrderCodeDesc()).thenReturn(Optional.of(order));
+
+        Short code = provider.getLastOrderCode();
+
+        assertEquals(order.getOrderCode(), code);
+    }
+
+    @Test
+    void getLastOrderCodeEmpty() {
+        when(repository.findFirstByOrderByOrderCodeDesc()).thenReturn(Optional.empty());
+
+        Short code = provider.getLastOrderCode();
+
+        assertEquals(0, code);
+    }
+}

--- a/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/PaymentDataProviderTest.java
+++ b/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/PaymentDataProviderTest.java
@@ -1,0 +1,44 @@
+package com.fiap.fast_food_tc.unit.adapter.provider;
+
+import com.fiap.fast_food_tc.adapter.db.model.Payment;
+import com.fiap.fast_food_tc.adapter.db.repository.PaymentRepository;
+import com.fiap.fast_food_tc.adapter.provider.PaymentDataProvider;
+import com.fiap.fast_food_tc.cross.enums.PaymentMethod;
+import com.fiap.fast_food_tc.cross.enums.PaymentStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentDataProviderTest {
+
+    @Mock
+    private PaymentRepository repository;
+
+    @InjectMocks
+    private PaymentDataProvider provider;
+
+    @Test
+    void saveSuccess() {
+        Payment payment = Payment.builder()
+                .paymentId(1)
+                .paymentMethod(PaymentMethod.MERCADO_PAGO)
+                .paymentStatus(PaymentStatus.PENDING)
+                .paymentValue(BigDecimal.TEN)
+                .createdAt(LocalDateTime.now())
+                .build();
+        when(repository.save(payment)).thenReturn(payment);
+
+        var result = provider.save(payment);
+
+        assertEquals(payment, result);
+    }
+}

--- a/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/ProductDataProviderTest.java
+++ b/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/ProductDataProviderTest.java
@@ -1,0 +1,85 @@
+package com.fiap.fast_food_tc.unit.adapter.provider;
+
+import com.fiap.fast_food_tc.adapter.db.model.Product;
+import com.fiap.fast_food_tc.adapter.db.repository.ProductRepository;
+import com.fiap.fast_food_tc.adapter.provider.ProductDataProvider;
+import fixture.ProductFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductDataProviderTest {
+
+    @Mock
+    private ProductRepository repository;
+
+    @InjectMocks
+    private ProductDataProvider provider;
+
+    @Test
+    void createSuccess() {
+        Product model = ProductFixture.createProduct();
+        when(repository.save(model)).thenReturn(model);
+
+        var result = provider.create(model);
+
+        assertEquals(model, result);
+    }
+
+    @Test
+    void findAllSuccess() {
+        List<Product> list = List.of(ProductFixture.createProduct());
+        when(repository.findAll()).thenReturn(list);
+
+        var result = provider.findAll();
+
+        assertEquals(list, result);
+    }
+
+    @Test
+    void updateSuccess() {
+        Product model = ProductFixture.createProduct();
+        when(repository.save(any())).thenReturn(model);
+
+        var result = provider.update(model);
+
+        assertEquals(model, result);
+    }
+
+    @Test
+    void deleteSuccess() {
+        provider.delete(1);
+
+        verify(repository).deleteById(1);
+    }
+
+    @Test
+    void findByIdSuccess() {
+        Product model = ProductFixture.createProduct();
+        when(repository.findById(1)).thenReturn(Optional.of(model));
+
+        var result = provider.findById(1);
+
+        assertEquals(model, result);
+    }
+
+    @Test
+    void findByCategoryIdSuccess() {
+        List<Product> list = List.of(ProductFixture.createProduct());
+        when(repository.findByCategoryCategoryId(1)).thenReturn(list);
+
+        var result = provider.findByCategoryId(1);
+
+        assertEquals(list, result);
+    }
+}

--- a/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/clients/MercadoPagoClientTest.java
+++ b/src/test/java/com/fiap/fast_food_tc/unit/adapter/provider/clients/MercadoPagoClientTest.java
@@ -1,0 +1,53 @@
+package com.fiap.fast_food_tc.unit.adapter.provider.clients;
+
+import com.fiap.fast_food_tc.adapter.dto.checkout.PreferenceRequest;
+import com.fiap.fast_food_tc.adapter.dto.checkout.PreferenceResponse;
+import com.fiap.fast_food_tc.adapter.provider.clients.MercadoPagoClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MercadoPagoClientTest {
+
+    @Mock
+    private WebClient webClient;
+    @Mock
+    private WebClient.RequestBodyUriSpec uriSpec;
+    @Mock
+    private WebClient.RequestHeadersSpec<?> headersSpec;
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    private MercadoPagoClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = new MercadoPagoClient(webClient, "token");
+    }
+
+    @Test
+    void createPreferenceSuccess() {
+        PreferenceRequest request = new PreferenceRequest();
+        PreferenceResponse response = PreferenceResponse.builder().id("1").initPoint("url").build();
+
+        when(webClient.post()).thenReturn(uriSpec);
+        when(uriSpec.uri("/checkout/preferences")).thenReturn(uriSpec);
+        when(uriSpec.header(HttpHeaders.AUTHORIZATION, "Bearer token")).thenReturn(uriSpec);
+        when(uriSpec.bodyValue(request)).thenReturn(headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(PreferenceResponse.class)).thenReturn(Mono.just(response));
+
+        var result = client.createPreference(request);
+
+        assertEquals(response, result);
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for data provider classes
- include test for MercadoPago client

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683e24f8799c832896804c8b1da4f517