### PR TITLE
Refactor payment to enforce clean architecture

### DIFF
--- a/src/main/java/com/fiap/fast_food_tc/domain/gateway/PaymentGateway.java
+++ b/src/main/java/com/fiap/fast_food_tc/domain/gateway/PaymentGateway.java
@@ -1,13 +1,14 @@
 package com.fiap.fast_food_tc.domain.gateway;
 
-import com.fiap.fast_food_tc.infra.db.model.Payment;
+import com.fiap.fast_food_tc.domain.entity.EPayment;
+import java.util.List;
 
 public interface PaymentGateway {
 
-    Payment save(Payment payment);
+    EPayment save(EPayment payment);
 
-    Payment findById(Integer id);
+    EPayment findById(Integer id);
 
-    java.util.List<Payment> findAll();
+    List<EPayment> findAll();
 
 }

--- a/src/main/java/com/fiap/fast_food_tc/domain/usecase/impl/PaymentUseCaseImpl.java
+++ b/src/main/java/com/fiap/fast_food_tc/domain/usecase/impl/PaymentUseCaseImpl.java
@@ -1,6 +1,5 @@
 package com.fiap.fast_food_tc.domain.usecase.impl;
 
-import com.fiap.fast_food_tc.cross.mapper.PaymentMapper;
 import com.fiap.fast_food_tc.domain.entity.EPayment;
 import com.fiap.fast_food_tc.domain.gateway.PaymentGateway;
 import com.fiap.fast_food_tc.domain.usecase.PaymentUseCase;
@@ -13,26 +12,24 @@ import java.util.List;
 public class PaymentUseCaseImpl implements PaymentUseCase {
 
     private final PaymentGateway gateway;
-    private final PaymentMapper mapper;
 
     @Autowired
-    public PaymentUseCaseImpl(PaymentGateway gateway, PaymentMapper mapper) {
+    public PaymentUseCaseImpl(PaymentGateway gateway) {
         this.gateway = gateway;
-        this.mapper = mapper;
     }
 
     @Override
     public EPayment create(EPayment payment) {
-        return mapper.toEntity(gateway.save(mapper.toModel(payment)));
+        return gateway.save(payment);
     }
 
     @Override
     public List<EPayment> findAll() {
-        return mapper.toEntityList(gateway.findAll());
+        return gateway.findAll();
     }
 
     @Override
     public EPayment findById(Integer id) {
-        return mapper.toEntity(gateway.findById(id));
+        return gateway.findById(id);
     }
 }

--- a/src/main/java/com/fiap/fast_food_tc/infra/provider/CheckoutDataProvider.java
+++ b/src/main/java/com/fiap/fast_food_tc/infra/provider/CheckoutDataProvider.java
@@ -2,8 +2,8 @@ package com.fiap.fast_food_tc.infra.provider;
 
 import com.fiap.fast_food_tc.app.dto.checkout.MPPaymentResponse;
 import com.fiap.fast_food_tc.infra.db.model.Orders;
-import com.fiap.fast_food_tc.infra.db.model.Payment;
 import com.fiap.fast_food_tc.infra.db.model.Product;
+import com.fiap.fast_food_tc.domain.entity.EPayment;
 import com.fiap.fast_food_tc.app.dto.checkout.PreferenceRequest;
 import com.fiap.fast_food_tc.app.dto.checkout.PreferenceResponse;
 import com.fiap.fast_food_tc.infra.provider.clients.MercadoPagoClient;
@@ -37,7 +37,7 @@ public class CheckoutDataProvider implements CheckoutGateway {
     public void verifyApprovedPayment(String paymentId){
         MPPaymentResponse response = mercadoPagoClient.getPayment(paymentId);
         if (response != null && "approved".equalsIgnoreCase(response.getStatus())) {
-            Payment payment = paymentDataProvider.findByMercadoPagoId(paymentId);
+            EPayment payment = paymentDataProvider.findByMercadoPagoId(paymentId);
             payment.setPaymentStatus(PaymentStatus.APPROVED);
             paymentDataProvider.save(payment);
         }
@@ -54,7 +54,7 @@ public class CheckoutDataProvider implements CheckoutGateway {
         PreferenceRequest request = getPreferenceRequest(order);
         PreferenceResponse response = mercadoPagoClient.createPreference(request);
 
-        Payment payment = Payment.builder()
+        EPayment payment = EPayment.builder()
                 .customerId(order.getCustomer().getCustomerId())
                 .paymentValue(order.getTotalAmount())
                 .paymentStatus(PaymentStatus.PENDING)

--- a/src/main/java/com/fiap/fast_food_tc/infra/provider/PaymentDataProvider.java
+++ b/src/main/java/com/fiap/fast_food_tc/infra/provider/PaymentDataProvider.java
@@ -1,8 +1,10 @@
 package com.fiap.fast_food_tc.infra.provider;
 
+import com.fiap.fast_food_tc.domain.entity.EPayment;
+import com.fiap.fast_food_tc.domain.gateway.PaymentGateway;
 import com.fiap.fast_food_tc.infra.db.model.Payment;
 import com.fiap.fast_food_tc.infra.db.repository.PaymentRepository;
-import com.fiap.fast_food_tc.domain.gateway.PaymentGateway;
+import com.fiap.fast_food_tc.cross.mapper.PaymentMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -10,31 +12,36 @@ import org.springframework.stereotype.Component;
 public class PaymentDataProvider implements PaymentGateway {
 
     private final PaymentRepository repository;
+    private final PaymentMapper mapper;
 
     @Autowired
-    public PaymentDataProvider(PaymentRepository repository) {
+    public PaymentDataProvider(PaymentRepository repository, PaymentMapper mapper) {
         this.repository = repository;
+        this.mapper = mapper;
     }
 
     @Override
-    public Payment save(Payment payment) {
-        return repository.save(payment);
+    public EPayment save(EPayment payment) {
+        Payment model = repository.save(mapper.toModel(payment));
+        return mapper.toEntity(model);
     }
 
     @Override
-    public Payment findById(Integer id) {
-        return repository.findById(id)
+    public EPayment findById(Integer id) {
+        Payment model = repository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Payment not found"));
+        return mapper.toEntity(model);
     }
 
     @Override
-    public java.util.List<Payment> findAll() {
-        return repository.findAll();
+    public java.util.List<EPayment> findAll() {
+        return mapper.toEntityList(repository.findAll());
     }
 
-    public Payment findByMercadoPagoId(String id) {
-        return repository.findByMercadoPagoId(id)
+    public EPayment findByMercadoPagoId(String id) {
+        Payment model = repository.findByMercadoPagoId(id)
                 .orElseThrow(() -> new IllegalArgumentException("Payment not found"));
+        return mapper.toEntity(model);
     }
 
 }


### PR DESCRIPTION
## Summary
- refactor PaymentGateway to depend on domain entity
- simplify PaymentUseCaseImpl so mapping occurs in provider
- update PaymentDataProvider for entity-model mapping
- adjust CheckoutDataProvider to work with new payment entity